### PR TITLE
[development] Common `results` notation for api results

### DIFF
--- a/betfund_bet365/client/__init__.py
+++ b/betfund_bet365/client/__init__.py
@@ -17,7 +17,7 @@ Responses are parsed into Facade Access objects (Base Bet365Response)
 
 
 __title__ = "betfund-bet365"
-__version__ = "0.0.4"
+__version__ = "0.0.6"
 __author__ = "Leon Kozlowski"
 __license__ = "MIT"
 

--- a/betfund_bet365/response/pre_match_odds.py
+++ b/betfund_bet365/response/pre_match_odds.py
@@ -51,7 +51,7 @@ class PreMatchOddsResponse(Bet365Response):
         super(PreMatchOddsResponse, self).__init__(data)
 
     @property
-    def events(self) -> Union[List[FiResultBase], None]:
+    def results(self) -> Union[List[FiResultBase], None]:
         """Access for `events`."""
         if not self._results:
             return None

--- a/betfund_bet365/response/upcoming_events.py
+++ b/betfund_bet365/response/upcoming_events.py
@@ -81,10 +81,10 @@ class UpcomingEventsResponse(Bet365Response):
     ...   },
     ... ]
 
-    >>> response_object.events[0].our_event_id
+    >>> response_object.results[0].our_event_id
     >>> "2294461"
 
-    >>> response_object.events[0].updated_at
+    >>> response_object.results[0].updated_at
     >>> "1586461906"
     """
 
@@ -94,8 +94,8 @@ class UpcomingEventsResponse(Bet365Response):
         self.pager = PagerBase(data.get("pager"))
 
     @property
-    def events(self) -> Union[List[UpcomingEvent], None]:
-        """Access for `events`."""
+    def results(self) -> Union[List[UpcomingEvent], None]:
+        """Access for `results`."""
         if not self._results:
             return None
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="betfund-bet365",
-    version="0.0.4",
+    version="0.0.6",
     description="High Throughput Wrapper for Bet365 API",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Quick Fix

In order to standardize downstream usage of this wrapper I am making response object top level structure common for all objects.

**For Example**
-All responses contain two common keys:

```python
{
    "success": 1,
    "results": []
}
```

I was originally calling two of them `"events"` for some reason -- bringing these all to `"results"` because downstream caller will use one helper to ingest results object.